### PR TITLE
Use correct "ByteCommandParameter" for three parameters

### DIFF
--- a/src/WinBeacon.Stack/Hci/Commands/LeSetAdvertisingParametersCommand.cs
+++ b/src/WinBeacon.Stack/Hci/Commands/LeSetAdvertisingParametersCommand.cs
@@ -69,9 +69,9 @@ namespace WinBeacon.Stack.Hci.Commands
 
             Parameters.Add(new UshortCommandParameter(minimumAdvertisingIntervalCode));
             Parameters.Add(new UshortCommandParameter(maximumAdvertisingIntervalCode));
-            Parameters.Add(new UshortCommandParameter((byte)advertisingType));
-            Parameters.Add(new UshortCommandParameter((byte)ownAdressType));
-            Parameters.Add(new UshortCommandParameter((byte)peerAdressType));
+            Parameters.Add(new ByteCommandParameter((byte)advertisingType));
+            Parameters.Add(new ByteCommandParameter((byte)ownAdressType));
+            Parameters.Add(new ByteCommandParameter((byte)peerAdressType));
             Parameters.Add(new ByteArrayCommandParameter(peerAddress));
             Parameters.Add(new ByteCommandParameter((byte)advertisingChannelMap));
             Parameters.Add(new ByteCommandParameter((byte)advertisingFilterPolicy));


### PR DESCRIPTION
Using "UshortCommandParameters" for advertisingType, ownAdressType and peerAdressType caused 3 "00"-Bytes extra within the parameter, causing the parameter to be ignored by the Bluetooth device. Changing this to the correct "ByteCommandParameter", the parameter holds 16 Bytes which are accepted by the Bluetooth device. Only by employing this change, the advertisment-Interval can be changed at all.